### PR TITLE
Install Git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get install -y sudo
 RUN apt-get install -y curl
 RUN apt-get install -y build-essential
 RUN apt-get install -y nano
+RUN apt-get install -y git
 
 #===========================================================================
 # Install Programming Languages. Add or remove languages as desired.


### PR DESCRIPTION
This is required for Go to work, but isn't installed by any of the other packages or metapackages. Also useful for importing code!